### PR TITLE
Timestamp column handling

### DIFF
--- a/Daves.DeepDataDuplicator.IntegrationTests.Database/Daves.DeepDataDuplicator.IntegrationTests.Database.sqlproj.user
+++ b/Daves.DeepDataDuplicator.IntegrationTests.Database/Daves.DeepDataDuplicator.IntegrationTests.Database.sqlproj.user
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <StartupScript>(Blank)</StartupScript>
+    <StartAction>StartNone</StartAction>
+    <CreateNewDatabase>True</CreateNewDatabase>
+  </PropertyGroup>
+</Project>

--- a/Daves.DeepDataDuplicator/Metadata/Column.cs
+++ b/Daves.DeepDataDuplicator/Metadata/Column.cs
@@ -6,11 +6,11 @@ namespace Daves.DeepDataDuplicator.Metadata
 {
     public class Column
     {
-        public Column(object tableId, object name, object columnId, object isNullable, object isIdentity, object isComputed)
-            : this((int)tableId, (string)name, (int)columnId, (bool)isNullable, (bool)isIdentity, (bool)isComputed)
+        public Column(object tableId, object name, object columnId, object isNullable, object isIdentity, object isComputed, object isTimestamp)
+            : this((int)tableId, (string)name, (int)columnId, (bool)isNullable, (bool)isIdentity, (bool)isComputed, (bool)isTimestamp)
         { }
 
-        public Column(int tableId, string name, int columnId, bool isNullable, bool isIdentity = false, bool isComputed = false)
+        public Column(int tableId, string name, int columnId, bool isNullable, bool isIdentity = false, bool isComputed = false, bool isTimestamp = false)
         {
             TableId = tableId;
             Name = name;
@@ -18,6 +18,7 @@ namespace Daves.DeepDataDuplicator.Metadata
             IsNullable = isNullable;
             IsIdentity = isIdentity;
             IsComputed = isComputed;
+            IsTimestamp = isTimestamp;
         }
 
         public int TableId { get; }
@@ -26,6 +27,7 @@ namespace Daves.DeepDataDuplicator.Metadata
         public bool IsNullable { get; }
         public bool IsIdentity { get; }
         public bool IsComputed { get; }
+        public bool IsTimestamp { get; }
         public Table Table { get; protected set; }
 
         public virtual void Initialize(IReadOnlyList<Table> tables)
@@ -35,7 +37,7 @@ namespace Daves.DeepDataDuplicator.Metadata
             => Name.ToLowercaseSpacelessName();
 
         public virtual bool IsCopyable
-            => !IsIdentity && !IsComputed;
+            => !IsIdentity && !IsComputed && !IsTimestamp;
 
         public override string ToString()
             => $"{Table}: {Name}";

--- a/Daves.DeepDataDuplicator/Metadata/Column.cs
+++ b/Daves.DeepDataDuplicator/Metadata/Column.cs
@@ -6,11 +6,11 @@ namespace Daves.DeepDataDuplicator.Metadata
 {
     public class Column
     {
-        public Column(object tableId, object name, object columnId, object isNullable, object isIdentity, object isComputed, object isTimestamp)
-            : this((int)tableId, (string)name, (int)columnId, (bool)isNullable, (bool)isIdentity, (bool)isComputed, (bool)isTimestamp)
+        public Column(object tableId, object name, object columnId, object isNullable, object isIdentity, object isComputed)
+            : this((int)tableId, (string)name, (int)columnId, (bool)isNullable, (bool)isIdentity, (bool)isComputed)
         { }
 
-        public Column(int tableId, string name, int columnId, bool isNullable, bool isIdentity = false, bool isComputed = false, bool isTimestamp = false)
+        public Column(int tableId, string name, int columnId, bool isNullable, bool isIdentity = false, bool isComputed = false)
         {
             TableId = tableId;
             Name = name;
@@ -18,7 +18,6 @@ namespace Daves.DeepDataDuplicator.Metadata
             IsNullable = isNullable;
             IsIdentity = isIdentity;
             IsComputed = isComputed;
-            IsTimestamp = isTimestamp;
         }
 
         public int TableId { get; }
@@ -27,7 +26,6 @@ namespace Daves.DeepDataDuplicator.Metadata
         public bool IsNullable { get; }
         public bool IsIdentity { get; }
         public bool IsComputed { get; }
-        public bool IsTimestamp { get; }
         public Table Table { get; protected set; }
 
         public virtual void Initialize(IReadOnlyList<Table> tables)
@@ -37,7 +35,7 @@ namespace Daves.DeepDataDuplicator.Metadata
             => Name.ToLowercaseSpacelessName();
 
         public virtual bool IsCopyable
-            => !IsIdentity && !IsComputed && !IsTimestamp;
+            => !IsIdentity && !IsComputed;
 
         public override string ToString()
             => $"{Table}: {Name}";

--- a/Daves.DeepDataDuplicator/Metadata/MetadataQuerier.cs
+++ b/Daves.DeepDataDuplicator/Metadata/MetadataQuerier.cs
@@ -31,14 +31,17 @@ FROM sys.tables";
 
         protected virtual string ColumnQuery =>
 @"SELECT
-    object_id tableId,
-    name name,
-    column_id columnId,
-    is_nullable isNullable,
-    is_identity isIdentity,
-    is_computed isComputed
-FROM sys.columns
-WHERE object_id IN (SELECT object_id FROM sys.tables)";
+    c.object_id tableId,
+    c.name name,
+    c.column_id columnId,
+    c.is_nullable isNullable,
+    c.is_identity isIdentity,
+    c.is_computed isComputed,
+    convert(bit, case t.name when 'timestamp' then 1 else 0 end) isTimestamp
+FROM sys.columns c
+join sys.types t
+  on t.user_type_id = c.user_type_id
+WHERE c.object_id IN (SELECT object_id FROM sys.tables)";
 
         protected virtual string PrimaryKeyQuery =>
 @"SELECT
@@ -100,7 +103,7 @@ WHERE parent_object_id IN (SELECT object_id FROM sys.tables)";
 
         public virtual IReadOnlyList<Column> QueryColumns()
             => Query(ColumnQuery,
-                r => new Column(r["tableId"], r["name"], r["columnId"], r["isNullable"], r["isIdentity"], r["isComputed"]))
+                r => new Column(r["tableId"], r["name"], r["columnId"], r["isNullable"], r["isIdentity"], r["isComputed"], r["isTimestamp"]))
             .ToReadOnlyList();
 
         public virtual IReadOnlyList<PrimaryKey> QueryPrimaryKeys()

--- a/Daves.DeepDataDuplicator/Metadata/MetadataQuerier.cs
+++ b/Daves.DeepDataDuplicator/Metadata/MetadataQuerier.cs
@@ -31,17 +31,14 @@ FROM sys.tables";
 
         protected virtual string ColumnQuery =>
 @"SELECT
-    c.object_id tableId,
-    c.name name,
-    c.column_id columnId,
-    c.is_nullable isNullable,
-    c.is_identity isIdentity,
-    c.is_computed isComputed,
-    convert(bit, case t.name when 'timestamp' then 1 else 0 end) isTimestamp
-FROM sys.columns c
-join sys.types t
-  on t.user_type_id = c.user_type_id
-WHERE c.object_id IN (SELECT object_id FROM sys.tables)";
+    object_id tableId,
+    name name,
+    column_id columnId,
+    is_nullable isNullable,
+    is_identity isIdentity,
+    is_computed isComputed
+FROM sys.columns
+WHERE object_id IN (SELECT object_id FROM sys.tables)";
 
         protected virtual string PrimaryKeyQuery =>
 @"SELECT
@@ -103,7 +100,7 @@ WHERE parent_object_id IN (SELECT object_id FROM sys.tables)";
 
         public virtual IReadOnlyList<Column> QueryColumns()
             => Query(ColumnQuery,
-                r => new Column(r["tableId"], r["name"], r["columnId"], r["isNullable"], r["isIdentity"], r["isComputed"], r["isTimestamp"]))
+                r => new Column(r["tableId"], r["name"], r["columnId"], r["isNullable"], r["isIdentity"], r["isComputed"]))
             .ToReadOnlyList();
 
         public virtual IReadOnlyList<PrimaryKey> QueryPrimaryKeys()


### PR DESCRIPTION
Don't try to copy timestamp columns. Doing so results in this SQL error, "Cannot insert an explicit value into a timestamp column. Use INSERT with a column list to exclude the timestamp column, or insert a DEFAULT into the timestamp column."